### PR TITLE
Disable "fi" ligature on Space Mono font

### DIFF
--- a/packages/crater/lib/stylesheets/_typography.scss
+++ b/packages/crater/lib/stylesheets/_typography.scss
@@ -3,5 +3,6 @@
 }
 
 @mixin secondary-font{
-  font-family: 'Roboto Mono', monospace;
+  font-family: 'Space Mono', monospace;
+  font-variant-ligatures: no-common-ligatures;
 }

--- a/packages/crater/lib/stylesheets/_typography.scss
+++ b/packages/crater/lib/stylesheets/_typography.scss
@@ -3,5 +3,5 @@
 }
 
 @mixin secondary-font{
-  font-family: 'Space Mono', monospace;
+  font-family: 'Roboto Mono', monospace;
 }


### PR DESCRIPTION
fixes [weird "fi" character spacing issue](https://github.com/thespacedojo/crater-nova/issues/6)
