### PR TITLE
Login Dropdown Fixes

### DIFF
--- a/packages/nova-base-styles/lib/stylesheets/_accounts.scss
+++ b/packages/nova-base-styles/lib/stylesheets/_accounts.scss
@@ -11,10 +11,10 @@
     margin-bottom: $vmargin;
   }
   .social-buttons{
-    @include flex-center;
+    align-items: center;
     justify-content: space-between;
     button{
-      margin-right: $hmargin;
+      margin-bottom: $vmargin;
       width: 100%;
       &.btn-twitter{
         background: #55acee;
@@ -25,8 +25,15 @@
         border-color: #3b5998;
       }
       &:last-child{
-        margin-right: 0;
+        margin-bottom: 0;
       }
     }
+  }
+}
+
+.users-account-menu{
+  .dropdown-menu{
+     min-width: 300px;
+     left: -75px;
   }
 }


### PR DESCRIPTION
1. Stack social buttons vertically
2. Widen the dropdown to 300px and move it -75px to the left (Feel free to remove/modify this; I did it so the "Enter username or email" placeholder text wouldn't get clipped and also so the dropdown doesn't get clipped at narrow screen widths)