### PR TITLE
SearchForm Bugfix

### DIFF
--- a/packages/nova-base-components/lib/common/SearchForm.jsx
+++ b/packages/nova-base-components/lib/common/SearchForm.jsx
@@ -25,12 +25,6 @@ class SearchForm extends Component{
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      search: this.props.router.location.query.query || ''
-    });
-  }
-
   search(data) {
 
     const router = this.props.router;


### PR DESCRIPTION
remove componentWillReceiveProps from SearchForm component
- it was resetting searchQuery when loading PostsSingle, which triggered a new search and a router.push

Let me know if there are any adverse effects to removing componentWillReceiveProps that I'm not aware of. This change fixes the bug behavior reported by Derek Braid here:
https://twitter.com/Royal_Arse/status/843509834314145792